### PR TITLE
select component update activeKey

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -33,7 +33,7 @@ async function genLessFile() {
         fs.readdir(componentsPath, (err, files) => {
             files.forEach(file => {
                 if (fs.existsSync(path.join(componentsPath, file, 'style', 'index.less'))) {
-                    componentsLessContent += `@import "../${path.join(file, 'style', 'index.less')}";\n`;
+                    componentsLessContent += `@import "../../${path.join(file, 'style', 'index.less')}";\n`;
                 }
             });
             fs.writeFileSync(

--- a/src/alert/style/index.less
+++ b/src/alert/style/index.less
@@ -1,12 +1,12 @@
 @import "../../core/styles/themes/default";
 @import "../../core/styles/mixins/index";
 
-@prefix-cls: ~"@{ant-prefix}-alert";
+@alert-prefix-cls: ~"@{ant-prefix}-alert";
 @alert-message-color: @heading-color;
 @alert-text-color: @text-color;
 @alert-close-color: @text-color-secondary;
 
-.@{prefix-cls} {
+.@{alert-prefix-cls} {
     .reset-component;
     position: relative;
     padding: 8px 15px 8px 37px;
@@ -35,7 +35,7 @@
     &-success {
         border: @border-width-base @border-style-base @alert-success-border-color;
         background-color: @alert-success-bg-color;
-        .@{prefix-cls}-icon {
+        .@{alert-prefix-cls}-icon {
             color: @alert-success-icon-color;
         }
     }
@@ -43,7 +43,7 @@
     &-info {
         border: @border-width-base @border-style-base @alert-info-border-color;
         background-color: @alert-info-bg-color;
-        .@{prefix-cls}-icon {
+        .@{alert-prefix-cls}-icon {
             color: @alert-info-icon-color;
         }
     }
@@ -51,7 +51,7 @@
     &-warning {
         border: @border-width-base @border-style-base @alert-warning-border-color;
         background-color: @alert-warning-bg-color;
-        .@{prefix-cls}-icon {
+        .@{alert-prefix-cls}-icon {
             color: @alert-warning-icon-color;
         }
     }
@@ -59,7 +59,7 @@
     &-error {
         border: @border-width-base @border-style-base @alert-error-border-color;
         background-color: @alert-error-bg-color;
-        .@{prefix-cls}-icon {
+        .@{alert-prefix-cls}-icon {
             color: @alert-error-icon-color;
         }
     }

--- a/src/anchor/style/index.less
+++ b/src/anchor/style/index.less
@@ -1,10 +1,10 @@
-@prefix-cls: ~"@{ant-prefix}-anchor";
+@anchor-prefix-cls: ~"@{ant-prefix}-anchor";
 @import "../../core/styles/themes/default";
 @import "../../core/styles/mixins/index";
 
 @anchor-border-width: 2px;
 
-.@{prefix-cls} {
+.@{anchor-prefix-cls} {
   .reset-component;
   position: relative;
   padding-left: @anchor-border-width;

--- a/src/avatar/style/index.less
+++ b/src/avatar/style/index.less
@@ -1,7 +1,7 @@
-@prefix-cls: ~"@{ant-prefix}-avatar";
+@avatar-prefix-cls: ~"@{ant-prefix}-avatar";
 @import "../../core/styles/themes/default";
 @import "../../core/styles/mixins/index";
-.@{prefix-cls} {
+.@{avatar-prefix-cls} {
     .reset-component;
     display: inline-block;
     text-align: center;
@@ -46,7 +46,7 @@
     & > * {
         line-height: @size;
     }
-    &.@{prefix-cls}-icon {
+    &.@{avatar-prefix-cls}-icon {
         font-size: @font-size;
     }
 }

--- a/src/back-top/style/index.less
+++ b/src/back-top/style/index.less
@@ -1,8 +1,8 @@
-@prefix-cls: ~"@{ant-prefix}-back-top";
+@backtop-prefix-cls: ~"@{ant-prefix}-back-top";
 @import "../../core/styles/themes/default";
 @import "../../core/styles/mixins/index";
 
-.@{prefix-cls}{
+.@{backtop-prefix-cls}{
 	.reset-component;
 	z-index: @zindex-back-top;
 	position: fixed;

--- a/src/back-top/style/responsive.less
+++ b/src/back-top/style/responsive.less
@@ -1,11 +1,11 @@
 @media screen and (max-width: @screen-md) {
-  .@{prefix-cls} {
+  .@{backtop-prefix-cls} {
     right: 60px;
   }
 }
 
 @media screen and (max-width: @screen-xs) {
-  .@{prefix-cls} {
+  .@{backtop-prefix-cls} {
     right: 20px;
   }
 }

--- a/src/badge/style/index.less
+++ b/src/badge/style/index.less
@@ -1,10 +1,10 @@
-@prefix-cls: ~"@{ant-prefix}-badge";
+@badge-prefix-cls: ~"@{ant-prefix}-badge";
 @number-prefix-cls: ~"@{ant-prefix}-scroll-number";
 @import "../../core/styles/themes/default";
 @import "../../core/styles/mixins/index";
 @import "../../core/styles/index";
 
-.@{prefix-cls} {
+.@{badge-prefix-cls} {
   .reset-component;
 
   position: relative;
@@ -126,7 +126,7 @@
   }
 
   &-not-a-wrapper {
-    &:not(.@{prefix-cls}-status) {
+    &:not(.@{badge-prefix-cls}-status) {
       vertical-align: middle;
     }
 
@@ -136,7 +136,7 @@
       display: block;
     }
 
-    .@{prefix-cls}-count {
+    .@{badge-prefix-cls}-count {
       transform: none;
     }
   }
@@ -190,7 +190,7 @@
   }
 }
 
-/*.@{prefix-cls} {
+/*.@{badge-prefix-cls} {
     .reset-component;
     position: relative;
     display: inline-block;
@@ -314,7 +314,7 @@
             position: relative;
         }
 
-        .@{prefix-cls}-count {
+        .@{badge-prefix-cls}-count {
             transform: none;
         }
     }

--- a/src/checkbox/style/index.less
+++ b/src/checkbox/style/index.less
@@ -1,9 +1,9 @@
-@prefix-cls: ~"@{ant-prefix}-checkbox";
-@inner-prefix-cls: ~"@{prefix-cls}-inner";
+@checkbox-prefix-cls: ~"@{ant-prefix}-checkbox";
+@inner-prefix-cls: ~"@{checkbox-prefix-cls}-inner";
 @import "../../core/styles/themes/default";
 @import "../../core/styles/mixins/index";
 
-.@{prefix-cls} {
+.@{checkbox-prefix-cls} {
     .reset-component;
 
     position: relative;
@@ -15,7 +15,7 @@
     outline: none;
     cursor: pointer;
 
-    .@{prefix-cls}-wrapper:hover &-inner,
+    .@{checkbox-prefix-cls}-wrapper:hover &-inner,
     &-input:focus + &-inner {
       border-color: @checkbox-color;
     }
@@ -35,7 +35,7 @@
     }
 
     &:hover::after,
-    .@{prefix-cls}-wrapper:hover &::after {
+    .@{checkbox-prefix-cls}-wrapper:hover &::after {
       visibility: visible;
     }
 
@@ -89,7 +89,7 @@
   }
 
   // 选中状态
-  .@{prefix-cls}-checked .@{inner-prefix-cls}::after {
+  .@{checkbox-prefix-cls}-checked .@{inner-prefix-cls}::after {
     position: absolute;
     display: table;
     border: 2px solid @checkbox-check-color;
@@ -101,24 +101,24 @@
     content: ' ';
   }
 
-  .@{prefix-cls}-checked {
+  .@{checkbox-prefix-cls}-checked {
     .@{inner-prefix-cls} {
       background-color: @checkbox-color;
       border-color: @checkbox-color;
     }
   }
 
-  .@{prefix-cls}-disabled {
+  .@{checkbox-prefix-cls}-disabled {
     cursor: not-allowed;
 
-    &.@{prefix-cls}-checked {
+    &.@{checkbox-prefix-cls}-checked {
       .@{inner-prefix-cls}::after {
         border-color: @disabled-color;
         animation-name: none;
       }
     }
 
-    .@{prefix-cls}-input {
+    .@{checkbox-prefix-cls}-input {
       cursor: not-allowed;
     }
 
@@ -138,7 +138,7 @@
     }
   }
 
-  .@{prefix-cls}-wrapper {
+  .@{checkbox-prefix-cls}-wrapper {
     .reset-component;
 
     display: inline-block;
@@ -149,13 +149,13 @@
     }
   }
 
-  .@{prefix-cls}-wrapper + span,
-  .@{prefix-cls} + span {
+  .@{checkbox-prefix-cls}-wrapper + span,
+  .@{checkbox-prefix-cls} + span {
     padding-right: 8px;
     padding-left: 8px;
   }
 
-  .@{prefix-cls}-group {
+  .@{checkbox-prefix-cls}-group {
     .reset-component;
 
     display: inline-block;
@@ -172,7 +172,7 @@
   }
 
   // 半选状态
-  .@{prefix-cls}-indeterminate {
+  .@{checkbox-prefix-cls}-indeterminate {
     .@{inner-prefix-cls} {
       background-color: #fff;
       border-color: @border-color-base;
@@ -192,7 +192,7 @@
       content: ' ';
     }
 
-    &.@{prefix-cls}-disabled .@{inner-prefix-cls}::after {
+    &.@{checkbox-prefix-cls}-disabled .@{inner-prefix-cls}::after {
       background-color: @disabled-color;
       border-color: @disabled-color;
     }

--- a/src/divider/style/index.less
+++ b/src/divider/style/index.less
@@ -1,8 +1,8 @@
-@prefix-cls: ~"@{ant-prefix}-divider";
+@divider-prefix-cls: ~"@{ant-prefix}-divider";
 @import "../../core/styles/themes/default";
 @import "../../core/styles/mixins/index";
 
-.@{prefix-cls} {
+.@{divider-prefix-cls} {
   .reset-component;
   background: @border-color-split;
  
@@ -48,7 +48,7 @@
   }
   &-horizontal&-with-text-left,
   &-horizontal&-with-text-right {
-    .@{prefix-cls}-inner-text {
+    .@{divider-prefix-cls}-inner-text {
       display: inline-block;
       padding: 0 10px;
     }

--- a/src/drawer/style/index.less
+++ b/src/drawer/style/index.less
@@ -1,8 +1,8 @@
 @import "../../core/styles/themes/default";
 
-@prefix-cls: ~"@{ant-prefix}-drawer";
+@drawer-prefix-cls: ~"@{ant-prefix}-drawer";
 
-.@{prefix-cls} {
+.@{drawer-prefix-cls} {
     position: fixed;
     left: 0; // add by bzx
 	top: 0;
@@ -16,7 +16,7 @@
 	&-content-wrapper {
 		position: fixed;
 	}
-	.@{prefix-cls}-content {
+	.@{drawer-prefix-cls}-content {
 		width: 100%;
 		height: 100%;
 	}
@@ -24,31 +24,31 @@
 	&-right {
 		width: 0%;
 		height: 100%;
-		.@{prefix-cls}-content-wrapper {
+		.@{drawer-prefix-cls}-content-wrapper {
 			height: 100%;
 		}
-		&.@{prefix-cls}-open {
+		&.@{drawer-prefix-cls}-open {
 			width: 100%;
 		}
-		&.@{prefix-cls}-open.no-mask {
+		&.@{drawer-prefix-cls}-open.no-mask {
 			width: 0%;
 		}
 	}
 	&-left {
-		&.@{prefix-cls}-open {
-			.@{prefix-cls}-content-wrapper {
+		&.@{drawer-prefix-cls}-open {
+			.@{drawer-prefix-cls}-content-wrapper {
 				box-shadow: @shadow-1-right;
 			}
 		}
 	}
 	&-right {
-		.@{prefix-cls} {
+		.@{drawer-prefix-cls} {
 			&-content-wrapper {
 				right: 0;
 			}
 		}
-		&.@{prefix-cls}-open {
-			.@{prefix-cls}-content-wrapper {
+		&.@{drawer-prefix-cls}-open {
+			.@{drawer-prefix-cls}-content-wrapper {
 				box-shadow: @shadow-1-left;
 			}
 		}
@@ -58,37 +58,37 @@
 	&-bottom {
 		width: 100%;
 		height: 0%;
-		.@{prefix-cls}-content-wrapper {
+		.@{drawer-prefix-cls}-content-wrapper {
 			width: 100%;
 		}
-		&.@{prefix-cls}-open {
+		&.@{drawer-prefix-cls}-open {
 			height: 100%;
 		}
-		&.@{prefix-cls}-open.no-mask {
+		&.@{drawer-prefix-cls}-open.no-mask {
 			height: 0%;
 		}
 	}
 	&-top {
-		&.@{prefix-cls}-open {
-			.@{prefix-cls}-content-wrapper {
+		&.@{drawer-prefix-cls}-open {
+			.@{drawer-prefix-cls}-content-wrapper {
 				box-shadow: @shadow-1-down;
 			}
 		}
 	}
 	&-bottom {
-		.@{prefix-cls} {
+		.@{drawer-prefix-cls} {
 			&-content-wrapper {
 				bottom: 0;
 			}
 		}
-		&.@{prefix-cls}-open {
-			.@{prefix-cls}-content-wrapper {
+		&.@{drawer-prefix-cls}-open {
+			.@{drawer-prefix-cls}-content-wrapper {
 				box-shadow: @shadow-1-up;
 			}
 		}
 	}
-	&.@{prefix-cls}-open {
-		.@{prefix-cls} {
+	&.@{drawer-prefix-cls}-open {
+		.@{drawer-prefix-cls} {
 			&-mask {
 				opacity: 0.3;
 				height: 100%;

--- a/src/icon/iconfont.js
+++ b/src/icon/iconfont.js
@@ -41,8 +41,11 @@ export default function (options = {}) {
             let useNode = this.el.querySelector('use');
             useNode.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', '#' + type);
         },
+        handleClick(e) {
+            this.fire('click', e);
+        },
         template: `
-            <span>
+            <span on-click="handleClick">
                 <s-icon
                     theme="{{theme}}"
                     spin="{{spin}}"

--- a/src/message/style/index.less
+++ b/src/message/style/index.less
@@ -1,9 +1,9 @@
 @import "../../core/styles/themes/default";
 @import "../../core/styles/mixins/index";
 
-@prefix-cls: ~"@{ant-prefix}-message";
+@message-prefix-cls: ~"@{ant-prefix}-message";
 
-.@{prefix-cls} {
+.@{message-prefix-cls} {
     .reset-component;
     position: fixed;
     z-index: @zindex-message;

--- a/src/pagination/style/index.less
+++ b/src/pagination/style/index.less
@@ -2,9 +2,9 @@
 @import "../../core/styles/mixins/index";
 @import "../../input/style/mixin";
 
-@prefix-cls: ~"@{ant-prefix}-pagination";
+@pagination-prefix-cls: ~"@{ant-prefix}-pagination";
 
-.@{prefix-cls} {
+.@{pagination-prefix-cls} {
   .reset-component;
   display:inline-block;
   ul,
@@ -87,10 +87,10 @@
   &-jump-prev,
   &-jump-next {
     outline: 0;
-    .@{prefix-cls}-item-container {
+    .@{pagination-prefix-cls}-item-container {
       position: relative;
 
-      .@{prefix-cls}-item-link-icon {
+      .@{pagination-prefix-cls}-item-link-icon {
         .iconfont-size-under-12px(12px);
         color: @primary-color;
         letter-spacing: -1px;
@@ -105,7 +105,7 @@
         }
       }
 
-      .@{prefix-cls}-item-ellipsis {
+      .@{pagination-prefix-cls}-item-ellipsis {
         position: absolute;
         display: block;
         letter-spacing: 2px;
@@ -123,10 +123,10 @@
 
     &:focus,
     &:hover {
-      .@{prefix-cls}-item-link-icon {
+      .@{pagination-prefix-cls}-item-link-icon {
         opacity: 1;
       }
-      .@{prefix-cls}-item-ellipsis {
+      .@{pagination-prefix-cls}-item-ellipsis {
         opacity: 0;
       }
     }
@@ -168,7 +168,7 @@
       border-color: @primary-5;
     }
 
-    .@{prefix-cls}-item-link {
+    .@{pagination-prefix-cls}-item-link {
       border: @border-width-base @border-style-base @border-color-base;
       background-color: @component-background;
       border-radius: @border-radius-base;
@@ -180,8 +180,8 @@
       text-align: center;
     }
 
-    &:focus .@{prefix-cls}-item-link,
-    &:hover .@{prefix-cls}-item-link {
+    &:focus .@{pagination-prefix-cls}-item-link,
+    &:hover .@{pagination-prefix-cls}-item-link {
       border-color: @primary-color;
       color: @primary-color;
     }
@@ -193,7 +193,7 @@
     &:focus {
       cursor: not-allowed;
       a,
-      .@{prefix-cls}-item-link {
+      .@{pagination-prefix-cls}-item-link {
         border-color: @border-color-base;
         color: @disabled-color;
         cursor: not-allowed;
@@ -265,7 +265,7 @@
     height: @pagination-item-size-sm;
     line-height: @pagination-item-size-sm;
     vertical-align: top;
-    .@{prefix-cls}-item-link {
+    .@{pagination-prefix-cls}-item-link {
       border: 0;
       height: @pagination-item-size-sm;
       &:after {
@@ -387,7 +387,7 @@
   &&-disabled {
     cursor: not-allowed;
 
-    .@{prefix-cls}-item {
+    .@{pagination-prefix-cls}-item {
       background: @disabled-bg;
       border-color: @border-color-base;
       cursor: not-allowed;
@@ -408,7 +408,7 @@
       }
     }
 
-    .@{prefix-cls}-item-link {
+    .@{pagination-prefix-cls}-item-link {
       &,
       &:hover,
       &:focus {
@@ -419,14 +419,14 @@
       }
     }
 
-    .@{prefix-cls}-jump-prev,
-    .@{prefix-cls}-jump-next {
+    .@{pagination-prefix-cls}-jump-prev,
+    .@{pagination-prefix-cls}-jump-next {
       &:focus,
       &:hover {
-        .@{prefix-cls}-item-link-icon {
+        .@{pagination-prefix-cls}-item-link-icon {
           opacity: 0;
         }
-        .@{prefix-cls}-item-ellipsis {
+        .@{pagination-prefix-cls}-item-ellipsis {
           opacity: 1;
         }
       }
@@ -435,7 +435,7 @@
 }
 
 @media only screen and (max-width: @screen-lg) {
-  .@{prefix-cls}-item {
+  .@{pagination-prefix-cls}-item {
     &-after-jump-prev,
     &-before-jump-next {
       display: none;
@@ -444,7 +444,7 @@
 }
 
 @media only screen and (max-width: @screen-sm) {
-  .@{prefix-cls}-options {
+  .@{pagination-prefix-cls}-options {
     display: none;
   }
 }

--- a/src/progress/style/index.less
+++ b/src/progress/style/index.less
@@ -1,9 +1,9 @@
 @import "../../core/styles/themes/default";
 @import "../../core/styles/mixins/index";
 
-@prefix-cls: ~"@{ant-prefix}-progress";
+@progress-prefix-cls: ~"@{ant-prefix}-progress";
 
-.@{prefix-cls} {
+.@{progress-prefix-cls} {
   .reset-component;
   display: inline-block;
 
@@ -24,7 +24,7 @@
     width: 100%;
     margin-right: 0;
     padding-right: 0;
-    .@{prefix-cls}-show-info & {
+    .@{progress-prefix-cls}-show-info & {
       padding-right: ~"calc(2em + 8px)";
       margin-right: ~"calc(-2em - 8px)";
     }
@@ -80,7 +80,7 @@
   }
 
   &-status-active {
-    .@{prefix-cls}-bg:before {
+    .@{progress-prefix-cls}-bg:before {
       content: "";
       opacity: 0;
       position: absolute;
@@ -95,25 +95,25 @@
   }
 
   &-status-exception {
-    .@{prefix-cls}-bg {
+    .@{progress-prefix-cls}-bg {
       background-color: @error-color;
     }
-    .@{prefix-cls}-text {
+    .@{progress-prefix-cls}-text {
       color: @error-color;
     }
-    .@{prefix-cls}-circle-path {
+    .@{progress-prefix-cls}-circle-path {
       stroke: @error-color;
     }
   }
 
   &-status-success {
-    .@{prefix-cls}-bg {
+    .@{progress-prefix-cls}-bg {
       background-color: @success-color;
     }
-    .@{prefix-cls}-text {
+    .@{progress-prefix-cls}-text {
       color: @success-color;
     }
-    .@{prefix-cls}-circle-path {
+    .@{progress-prefix-cls}-circle-path {
       stroke: @success-color;
     }
   }
@@ -144,12 +144,12 @@
   }
 
   &-circle&-status-exception {
-    .@{prefix-cls}-text {
+    .@{progress-prefix-cls}-text {
       color: @error-color;
     }
   }
   &-circle&-status-success {
-    .@{prefix-cls}-text {
+    .@{progress-prefix-cls}-text {
       color: @success-color;
     }
   }

--- a/src/rate/style/index.less
+++ b/src/rate/style/index.less
@@ -1,11 +1,11 @@
-@prefix-cls: ~"@{ant-prefix}-rate";
+@rate-prefix-cls: ~"@{ant-prefix}-rate";
 @import "../../core/styles/themes/default";
 @import "../../core/styles/mixins/index";
 
 @rate-star-color: #fadb14;
 @font-size-base: 13px;
 
-.@{prefix-cls} {
+.@{rate-prefix-cls} {
   margin: 0;
   padding: 0;
   list-style: none;

--- a/src/row/index.js
+++ b/src/row/index.js
@@ -2,7 +2,6 @@
  * @file 组件 row
  * @author wangyongqing01 <wangyongqing01@baidu.com>
  */
-import './style';
 import {Row} from '../grid';
 
 export default Row;

--- a/src/select/DropdownMenu.js
+++ b/src/select/DropdownMenu.js
@@ -246,6 +246,10 @@ export default san.defineComponent({
                 this.resetActiveKey();
             }
         });
+
+        this.owner.watch('inputValue', value => {
+            this.data.set('activeKey', value);
+        });
     },
 
     getActiveItem() {
@@ -331,7 +335,7 @@ export default san.defineComponent({
     },
 
     handleMouseLeave() {
-        this.data.set('activeKey', '');
+        // this.data.set('activeKey', '');
     },
 
     handleMenuSelect({item}) {

--- a/src/spin/style/index.less
+++ b/src/spin/style/index.less
@@ -1,10 +1,10 @@
 @import "../../core/styles/themes/default";
 @import "../../core/styles/mixins/index";
 
-@prefix-cls: ~"@{ant-prefix}-spin";
+@spin-prefix-cls: ~"@{ant-prefix}-spin";
 @spin-dot-default: @text-color-secondary;
 
-.@{prefix-cls} {
+.@{spin-prefix-cls} {
   .reset-component;
   color: @primary-color;
   vertical-align: middle;
@@ -22,51 +22,51 @@
 
   &-nested-loading {
     position: relative;
-    > div > .@{prefix-cls} {
+    > div > .@{spin-prefix-cls} {
       display: block;
       position: absolute;
       height: 100%;
       max-height: 360px;
       width: 100%;
       z-index: 4;
-      .@{prefix-cls}-dot {
+      .@{spin-prefix-cls}-dot {
         position: absolute;
         top: 50%;
         left: 50%;
         margin: -@spin-dot-size / 2;
       }
-      .@{prefix-cls}-text {
+      .@{spin-prefix-cls}-text {
         position: absolute;
         top: 50%;
         width: 100%;
         padding-top: (@spin-dot-size - @font-size-base) / 2 + 2px;
         text-shadow: 0 1px 2px #fff;
       }
-      &.@{prefix-cls}-show-text .@{prefix-cls}-dot {
+      &.@{spin-prefix-cls}-show-text .@{spin-prefix-cls}-dot {
         margin-top: -@spin-dot-size / 2 - 10px;
       }
     }
 
-    > div > .@{prefix-cls}-sm {
-      .@{prefix-cls}-dot {
+    > div > .@{spin-prefix-cls}-sm {
+      .@{spin-prefix-cls}-dot {
         margin: -@spin-dot-size-sm / 2;
       }
-      .@{prefix-cls}-text {
+      .@{spin-prefix-cls}-text {
         padding-top: (@spin-dot-size-sm - @font-size-base) / 2 + 2px;
       }
-      &.@{prefix-cls}-show-text .@{prefix-cls}-dot {
+      &.@{spin-prefix-cls}-show-text .@{spin-prefix-cls}-dot {
         margin-top: -@spin-dot-size-sm / 2 - 10px;
       }
     }
 
-    > div > .@{prefix-cls}-lg {
-      .@{prefix-cls}-dot {
+    > div > .@{spin-prefix-cls}-lg {
+      .@{spin-prefix-cls}-dot {
         margin: -@spin-dot-size-lg / 2;
       }
-      .@{prefix-cls}-text {
+      .@{spin-prefix-cls}-text {
         padding-top: (@spin-dot-size-lg - @font-size-base) / 2 + 2px;
       }
-      &.@{prefix-cls}-show-text .@{prefix-cls}-dot {
+      &.@{spin-prefix-cls}-show-text .@{spin-prefix-cls}-dot {
         margin-top: -@spin-dot-size-lg / 2 - 10px;
       }
     }
@@ -189,7 +189,7 @@
 
 @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
   /* IE10+ */
-  .@{prefix-cls}-blur {
+  .@{spin-prefix-cls}-blur {
     background: @component-background;
     opacity: 0.5;
   }

--- a/src/switch/style/index.less
+++ b/src/switch/style/index.less
@@ -1,9 +1,9 @@
 @import "../../core/styles/themes/default";
 @import "../../core/styles/mixins/index";
-@prefix-cls: ~"@{ant-prefix}-switch";
+@switch-prefix-cls: ~"@{ant-prefix}-switch";
 @switch-duration: .36s;
 
-.@{prefix-cls} {
+.@{switch-prefix-cls} {
     .reset-component;
     position: relative;
     display: inline-block;
@@ -27,7 +27,7 @@
         display: block;
     }
 
-    & .@{prefix-cls}-handler,
+    & .@{switch-prefix-cls}-handler,
     &:after {
         position: absolute;
         width: @switch-height - 4px;
@@ -45,12 +45,12 @@
         box-shadow: 0 2px 4px 0 rgba(0, 35, 11, .2);
     }
 
-    &:active .@{prefix-cls}-handler,
+    &:active .@{switch-prefix-cls}-handler,
     &:active:after {
         width: 24px;
     }
 
-    & .@{prefix-cls}-handler {
+    & .@{switch-prefix-cls}-handler {
         font-family: 'anticon';
         animation: loadingCircle 1s infinite linear;
         text-align: center;
@@ -60,12 +60,12 @@
         font-size: 12px;
     }
 
-    &-loading .@{prefix-cls}-handler {
+    &-loading .@{switch-prefix-cls}-handler {
         display: inline-block;
         color: @text-color;
     }
 
-    &-checked&-loading .@{prefix-cls}-handler {
+    &-checked&-loading .@{switch-prefix-cls}-handler {
         color: @switch-color;
     }
 
@@ -83,37 +83,37 @@
         min-width: 28px;
         line-height: @switch-sm-height - 2px;
 
-        .@{prefix-cls}-inner {
+        .@{switch-prefix-cls}-inner {
             margin-left: 18px;
             margin-right: 3px;
             font-size: @font-size-sm;
         }
 
-        & .@{prefix-cls}-handler,
+        & .@{switch-prefix-cls}-handler,
         &:after {
             width: @switch-sm-height - 4px;
             height: @switch-sm-height - 4px;
         }
 
-        &:active .@{prefix-cls}-handler,
+        &:active .@{switch-prefix-cls}-handler,
         &:active:after {
             width: 16px;
         }
     }
 
     &-small&-checked {
-        & .@{prefix-cls}-handler {
+        & .@{switch-prefix-cls}-handler {
             left: 100%;
             margin-left: @switch-sm-checked-margin-left;
         }
 
-        .@{prefix-cls}-inner {
+        .@{switch-prefix-cls}-inner {
             margin-left: 3px;
             margin-right: 18px;
         }
     }
 
-    &-small&-loading .@{prefix-cls}-handler {
+    &-small&-loading .@{switch-prefix-cls}-handler {
         animation: AntSwitchSmallLoadingCircle 1s infinite linear;
         font-weight: bold;
     }
@@ -121,12 +121,12 @@
     &-checked {
         background-color: @switch-color;
 
-        .@{prefix-cls}-inner {
+        .@{switch-prefix-cls}-inner {
             margin-left: 6px;
             margin-right: 24px;
         }
 
-        & .@{prefix-cls}-handler {
+        & .@{switch-prefix-cls}-handler {
             left: 100%;
             margin-left: -19px;
         }

--- a/src/tabs/style/cardStyle.less
+++ b/src/tabs/style/cardStyle.less
@@ -1,8 +1,8 @@
 @import "../../core/styles/themes/default";
 @import "../../core/styles/mixins/index";
-@prefix-cls: ~"@{ant-prefix}-tabs";
+@tabs-prefix-cls: ~"@{ant-prefix}-tabs";
 
-.@{prefix-cls} {
+.@{tabs-prefix-cls} {
   &&-card &-card-bar &-nav-container {
     height: @tabs-card-height;
   }
@@ -64,7 +64,7 @@
   &-extra-content {
     line-height: @tabs-card-height;
 
-    .@{prefix-cls}-new-tab {
+    .@{tabs-prefix-cls}-new-tab {
       position: relative;
       width: 20px;
       height: 20px;
@@ -94,10 +94,10 @@
   // https://github.com/ant-design/ant-design/issues/4669
   &-vertical&-card &-card-bar&-left-bar,
   &-vertical&-card &-card-bar&-right-bar {
-    .@{prefix-cls}-nav-container {
+    .@{tabs-prefix-cls}-nav-container {
       height: auto;
     }
-    .@{prefix-cls}-tab {
+    .@{tabs-prefix-cls}-tab {
       margin-bottom: 8px;
       border-bottom: @border-width-base @border-style-base @border-color-split;
       &-active {
@@ -107,16 +107,16 @@
         margin-bottom: 8px;
       }
     }
-    .@{prefix-cls}-new-tab {
+    .@{tabs-prefix-cls}-new-tab {
       width: 90%;
     }
   }
 
   &-vertical&-card&-left &-card-bar&-left-bar {
-    .@{prefix-cls}-nav-wrap {
+    .@{tabs-prefix-cls}-nav-wrap {
       margin-right: 0;
     }
-    .@{prefix-cls}-tab {
+    .@{tabs-prefix-cls}-tab {
       margin-right: 1px;
       border-right: 0;
       border-radius: @border-radius-base 0 0 @border-radius-base;
@@ -128,10 +128,10 @@
   }
 
   &-vertical&-card&-right &-card-bar&-right-bar {
-    .@{prefix-cls}-nav-wrap {
+    .@{tabs-prefix-cls}-nav-wrap {
       margin-left: 0;
     }
-    .@{prefix-cls}-tab {
+    .@{tabs-prefix-cls}-tab {
       margin-left: 1px;
       border-left: 0;
       border-radius: 0 @border-radius-base @border-radius-base 0;

--- a/src/tabs/style/index.less
+++ b/src/tabs/style/index.less
@@ -2,7 +2,7 @@
 @import "../../core/styles/mixins/index";
 @import "./cardStyle";
 
-@prefix-cls: ~"@{ant-prefix}-tabs";
+@tabs-prefix-cls: ~"@{ant-prefix}-tabs";
 
 .tabs-hidden-content() {
   height: 0;
@@ -15,7 +15,7 @@
   }
 }
 
-.@{prefix-cls} {
+.@{tabs-prefix-cls} {
   .reset-component;
 
   position: relative;
@@ -91,7 +91,7 @@
     user-select: none;
     pointer-events: none;
 
-    &.@{prefix-cls}-tab-arrow-show {
+    &.@{tabs-prefix-cls}-tab-arrow-show {
       width: @tabs-scrolling-size;
       height: 100%;
       opacity: 1;
@@ -169,7 +169,7 @@
       clear: both;
     }
 
-    .@{prefix-cls}-tab {
+    .@{tabs-prefix-cls}-tab {
       position: relative;
       display: inline-block;
       box-sizing: border-box;
@@ -211,41 +211,41 @@
     }
   }
 
-  .@{prefix-cls}-large-bar {
-    .@{prefix-cls}-nav-container {
+  .@{tabs-prefix-cls}-large-bar {
+    .@{tabs-prefix-cls}-nav-container {
       font-size: @tabs-title-font-size-lg;
     }
-    .@{prefix-cls}-tab {
+    .@{tabs-prefix-cls}-tab {
       padding: @tabs-horizontal-padding-lg;
     }
   }
 
-  .@{prefix-cls}-small-bar {
-    .@{prefix-cls}-nav-container {
+  .@{tabs-prefix-cls}-small-bar {
+    .@{tabs-prefix-cls}-nav-container {
       font-size: @tabs-title-font-size-sm;
     }
-    .@{prefix-cls}-tab {
+    .@{tabs-prefix-cls}-tab {
       padding: @tabs-horizontal-padding-sm;
     }
   }
 
   // Horizontal Content
-  .@{prefix-cls}-top-content,
-  .@{prefix-cls}-bottom-content {
+  .@{tabs-prefix-cls}-top-content,
+  .@{tabs-prefix-cls}-bottom-content {
     width: 100%;
 
-    > .@{prefix-cls}-tabpane {
+    > .@{tabs-prefix-cls}-tabpane {
       flex-shrink: 0;
       width: 100%;
       opacity: 1;
       transition: opacity 0.45s;
     }
 
-    > .@{prefix-cls}-tabpane-inactive {
+    > .@{tabs-prefix-cls}-tabpane-inactive {
       .tabs-hidden-content();
     }
 
-    &.@{prefix-cls}-content-animated {
+    &.@{tabs-prefix-cls}-content-animated {
       display: flex;
       flex-direction: row;
       transition: margin-left 0.3s @ease-in-out;
@@ -254,8 +254,8 @@
   }
 
   // Vertical Bar
-  .@{prefix-cls}-left-bar,
-  .@{prefix-cls}-right-bar {
+  .@{tabs-prefix-cls}-left-bar,
+  .@{tabs-prefix-cls}-right-bar {
     height: 100%;
     border-bottom: 0;
     &-tab-prev,
@@ -264,13 +264,13 @@
       height: 0;
       transition: height 0.3s @ease-in-out, opacity 0.3s @ease-in-out, color 0.3s @ease-in-out;
     }
-    &-tab-prev.@{prefix-cls}-tab-arrow-show,
-    &-tab-next.@{prefix-cls}-tab-arrow-show {
+    &-tab-prev.@{tabs-prefix-cls}-tab-arrow-show,
+    &-tab-next.@{tabs-prefix-cls}-tab-arrow-show {
       width: 100%;
       height: @tabs-scrolling-size;
     }
 
-    .@{prefix-cls}-tab {
+    .@{tabs-prefix-cls}-tab {
       display: block;
       float: none;
       margin: @tabs-vertical-margin;
@@ -281,36 +281,36 @@
       }
     }
 
-    .@{prefix-cls}-extra-content {
+    .@{tabs-prefix-cls}-extra-content {
       text-align: center;
     }
 
-    .@{prefix-cls}-nav-scroll {
+    .@{tabs-prefix-cls}-nav-scroll {
       width: auto;
     }
 
-    .@{prefix-cls}-nav-container,
-    .@{prefix-cls}-nav-wrap {
+    .@{tabs-prefix-cls}-nav-container,
+    .@{tabs-prefix-cls}-nav-wrap {
       height: 100%;
     }
 
-    .@{prefix-cls}-nav-container {
+    .@{tabs-prefix-cls}-nav-container {
       margin-bottom: 0;
 
-      &.@{prefix-cls}-nav-container-scrolling {
+      &.@{tabs-prefix-cls}-nav-container-scrolling {
         padding: @tabs-scrolling-size 0;
       }
     }
 
-    .@{prefix-cls}-nav-wrap {
+    .@{tabs-prefix-cls}-nav-wrap {
       margin-bottom: 0;
     }
 
-    .@{prefix-cls}-nav {
+    .@{tabs-prefix-cls}-nav {
       width: 100%;
     }
 
-    .@{prefix-cls}-ink-bar {
+    .@{tabs-prefix-cls}-ink-bar {
       top: 0;
       bottom: auto;
       left: auto;
@@ -318,13 +318,13 @@
       height: auto;
     }
 
-    .@{prefix-cls}-tab-next {
+    .@{tabs-prefix-cls}-tab-next {
       bottom: 0;
       width: 100%;
       height: @tabs-scrolling-size;
     }
 
-    .@{prefix-cls}-tab-prev {
+    .@{tabs-prefix-cls}-tab-prev {
       top: 0;
       width: 100%;
       height: @tabs-scrolling-size;
@@ -332,88 +332,88 @@
   }
 
   // Vertical Content
-  .@{prefix-cls}-left-content,
-  .@{prefix-cls}-right-content {
+  .@{tabs-prefix-cls}-left-content,
+  .@{tabs-prefix-cls}-right-content {
     width: auto;
     margin-top: 0 !important;
     overflow: hidden;
   }
 
   // Vertical - Left
-  .@{prefix-cls}-left-bar {
+  .@{tabs-prefix-cls}-left-bar {
     float: left;
     margin-right: -1px;
     margin-bottom: 0;
     border-right: @border-width-base @border-style-base @border-color-split;
-    .@{prefix-cls}-tab {
+    .@{tabs-prefix-cls}-tab {
       text-align: right;
     }
-    .@{prefix-cls}-nav-container {
+    .@{tabs-prefix-cls}-nav-container {
       margin-right: -1px;
     }
-    .@{prefix-cls}-nav-wrap {
+    .@{tabs-prefix-cls}-nav-wrap {
       margin-right: -1px;
     }
-    .@{prefix-cls}-ink-bar {
+    .@{tabs-prefix-cls}-ink-bar {
       right: 1px;
     }
   }
-  .@{prefix-cls}-left-content {
+  .@{tabs-prefix-cls}-left-content {
     padding-left: 24px;
     border-left: @border-width-base @border-style-base @border-color-split;
   }
 
   // Vertical - Right
-  .@{prefix-cls}-right-bar {
+  .@{tabs-prefix-cls}-right-bar {
     float: right;
     margin-bottom: 0;
     margin-left: -1px;
     border-left: @border-width-base @border-style-base @border-color-split;
-    .@{prefix-cls}-nav-container {
+    .@{tabs-prefix-cls}-nav-container {
       margin-left: -1px;
     }
-    .@{prefix-cls}-nav-wrap {
+    .@{tabs-prefix-cls}-nav-wrap {
       margin-left: -1px;
     }
-    .@{prefix-cls}-ink-bar {
+    .@{tabs-prefix-cls}-ink-bar {
       left: 1px;
     }
   }
-  .@{prefix-cls}-right-content {
+  .@{tabs-prefix-cls}-right-content {
     padding-right: 24px;
     border-right: @border-width-base @border-style-base @border-color-split;
   }
 }
 
-.@{prefix-cls}-top .@{prefix-cls}-ink-bar-animated,
-.@{prefix-cls}-bottom .@{prefix-cls}-ink-bar-animated {
+.@{tabs-prefix-cls}-top .@{tabs-prefix-cls}-ink-bar-animated,
+.@{tabs-prefix-cls}-bottom .@{tabs-prefix-cls}-ink-bar-animated {
   transition: transform 0.3s @ease-in-out, width 0.3s @ease-in-out, left 0.3s @ease-in-out;
 }
 
-.@{prefix-cls}-left .@{prefix-cls}-ink-bar-animated,
-.@{prefix-cls}-right .@{prefix-cls}-ink-bar-animated {
+.@{tabs-prefix-cls}-left .@{tabs-prefix-cls}-ink-bar-animated,
+.@{tabs-prefix-cls}-right .@{tabs-prefix-cls}-ink-bar-animated {
   transition: transform 0.3s @ease-in-out, height 0.3s @ease-in-out, top 0.3s @ease-in-out;
 }
 
 // No animation
 .tabs-no-animation() {
-  > .@{prefix-cls}-content-animated {
+  > .@{tabs-prefix-cls}-content-animated {
     margin-left: 0 !important;
     transform: none !important;
   }
-  > .@{prefix-cls}-tabpane-inactive {
+  > .@{tabs-prefix-cls}-tabpane-inactive {
     .tabs-hidden-content();
   }
 }
 
 .no-flex,
-.@{prefix-cls}-no-animation {
-  > .@{prefix-cls}-content {
+.@{tabs-prefix-cls}-no-animation {
+  > .@{tabs-prefix-cls}-content {
     .tabs-no-animation();
   }
 }
 
-.@{prefix-cls}-left-content,
-.@{prefix-cls}-right-content {
+.@{tabs-prefix-cls}-left-content,
+.@{tabs-prefix-cls}-right-content {
   .tabs-no-animation();
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22813372/76691933-0b0b5200-668b-11ea-81cc-fdfbe3ab5758.png)
希望在输入的内容没有匹配到的时候，按回车可以直接选中，而不是需要先按向下的键盘，所以监听inputValue自动设置activeKey，当用户鼠标移除的时候也就不需要清空activeKey了。
这是按照ant的形式的，还有就是active 和 select 的颜色与ant是反的（这个没动），不知道是否与原本的设计有冲突。

commit ：update release less path
修复了引入 全部less文件的时候 路径错误的问题
![image](https://user-images.githubusercontent.com/22813372/80065643-0df04100-856d-11ea-90df-0c17fa845d0d.png)

commit : repair iconfont cannot be clicked
自定义font图标的时候不能点击

commit: fix row组件多引入了syle文件
row 组件多引入了样式文件 当不引入样式文件的时候，还是多引入一遍core的样式

commit: rename prefix-cls
prefix-cls的变量名相同 当引入全部组件样式的less文件的时候 很多组件样式没有被编译进去 被后面的prefix-cls覆盖了 按照ant的源码各组件也都区分了名称