### PR TITLE
index.js 文件中引入Statistic组件

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ export {default as Progress} from './progress';
 export {default as Radio} from './radio';
 export {default as Rate} from './rate';
 export {default as Row} from './row';
+export {default as Statistic} from './statistic';
 export {default as Select} from './select';
 export {default as Skeleton} from './skeleton';
 export {default as Slider} from './slider';

--- a/src/table/table.js
+++ b/src/table/table.js
@@ -19,6 +19,7 @@ import Tbody from './tbody';
 import Thead from './thead';
 import Tooltip from '../tooltip';
 import './style/index';
+import '../pagination/style/index';
 
 const prefixCls = classCreator('table')();
 


### PR DESCRIPTION
src/index.js 没有手动引入Statistic组件会导致编译出来的文件在非按需导入的情况下找不到此组件