### PR TITLE
Menu组件新增溢出折叠功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     },
     "peerDependencies": {
         "moment": "^2.22.2",
-        "san": "^3.7.9"
+        "san": "^3.10.1"
     },
     "devDependencies": {
         "@babel/core": "^7.4.4",
@@ -125,7 +125,7 @@
         "rollup-plugin-svgo": "^1.1.0",
         "rollup-plugin-terser": "^5.1.2",
         "rucksack-css": "^1.0.2",
-        "san": "^3.7.9",
+        "san": "^3.10.1",
         "san-hot-reload-api": "^1.0.1",
         "san-loader": "^0.2.0",
         "san-router": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     },
     "peerDependencies": {
         "moment": "^2.22.2",
-        "san": "^3.10.1"
+        "san": "^3.9.3"
     },
     "devDependencies": {
         "@babel/core": "^7.4.4",

--- a/src/core/constants.js
+++ b/src/core/constants.js
@@ -4,3 +4,4 @@
  */
 
 export const CLASSNAME_PREFIX = 'santd';
+export const MENU_FOLDED_ITEM_ID = CLASSNAME_PREFIX + '-menu-folded-item';

--- a/src/core/util/dom.js
+++ b/src/core/util/dom.js
@@ -261,3 +261,16 @@ export function getScrollBarSize(fresh) {
     }
     return cached;
 }
+
+/**
+ * 获取指定层级的父节点
+ * @param {Object} node HTML节点
+ * @param {number=} num 父节点层级（可选）
+ * @return {Object} HTML节点
+ */
+export function getParentNode(node, num) {
+    if (!node) {
+        return;
+    }
+    return num ? getParentNode(node.parentNode, num - 1) : node;
+}

--- a/src/menu/docs/horizontal.md
+++ b/src/menu/docs/horizontal.md
@@ -26,8 +26,11 @@
                 <s-menu-item key="setting4">Option 4</s-menu-item>
             </s-menu-item-group>
         </s-sub-menu>
-        <s-menu-item key="alipay">
+        <s-menu-item key="link1">
             <a href="http://www.baidu.com" target="_blank" rel="noopener noreferrer">Navigation Four - Link</a>
+        </s-menu-item>
+        <s-menu-item key="link2">
+            <a href="https://github.com/ecomfe/santd" target="_blank" rel="noopener noreferrer">Navigation Five - Link</a>
         </s-menu-item>
     </s-menu>
   </div>

--- a/src/menu/menu.js
+++ b/src/menu/menu.js
@@ -195,7 +195,6 @@ export default san.defineComponent({
         },
         santd_menu_itemClick(payload) {
             this.fire('click', payload.value);
-            this.dispatch('santd_menu_itemClick', payload.value);
         },
         santd_menu_openChange(payload) {
             this.handleOpenChange(payload.value);

--- a/src/menu/menuItem.js
+++ b/src/menu/menuItem.js
@@ -112,6 +112,7 @@ export default san.defineComponent({
             on-click="handleClick($event)"
             on-mouseleave="handleMouseLeave($event)"
             on-mouseenter="handleMouseEnter($event)"
+            s-if="!isFolded"
         >
             <slot />
         </li>

--- a/src/menu/menuItem.js
+++ b/src/menu/menuItem.js
@@ -90,17 +90,7 @@ export default san.defineComponent({
         }
 
         const key = this.data.get('key');
-        this.dispatch('santd_menu_itemHover', {key, hover: true});
         this.dispatch('santd_menu_itemMouseEnter', {key, e});
-    },
-    handleMouseLeave(e) {
-        if (this.data.get('disabled')) {
-            return;
-        }
-
-        const key = this.data.get('key');
-        this.dispatch('santd_menu_itemHover', {key, hover: false});
-        this.dispatch('santd_menu_itemMouseLeave', {key, e});
     },
     template: `
         <li
@@ -110,7 +100,6 @@ export default san.defineComponent({
             aria-disabled="{{disabled}}"
             aria-selected="{{isSelected}}"
             on-click="handleClick($event)"
-            on-mouseleave="handleMouseLeave($event)"
             on-mouseenter="handleMouseEnter($event)"
             s-if="!isFolded"
         >

--- a/src/menu/style/index.less
+++ b/src/menu/style/index.less
@@ -357,7 +357,7 @@
       height: @menu-item-height;
       margin-top: @menu-item-vertical-margin;
       margin-bottom: @menu-item-vertical-margin;
-      padding: 0 16px;
+      padding: 0 34px 0 16px;
       overflow: hidden;
       font-size: @menu-item-font-size;
       line-height: @menu-item-height;
@@ -394,10 +394,6 @@
     .@{menu-prefix-cls}-item,
     .@{menu-prefix-cls}-submenu-title {
       width: ~'calc(100% + 1px)';
-    }
-
-    .@{menu-prefix-cls}-submenu-title {
-      padding-right: 34px;
     }
   }
 

--- a/src/menu/style/index.less
+++ b/src/menu/style/index.less
@@ -169,6 +169,9 @@
         transition: opacity 0.3s @ease-in-out, width 0.3s @ease-in-out;
       }
     }
+    .@{menu-prefix-cls}-fold-icon {
+      margin-right: 0;
+    }
   }
 
   & > &-item-divider {

--- a/src/menu/subMenu.js
+++ b/src/menu/subMenu.js
@@ -217,7 +217,11 @@ export default san.defineComponent({
                     <template s-else>{{title}}</template>
                     <i class="{{menuPrefixCls}}-arrow" />
                 </div>
-                <s-animate hiddenClassName="${prefixCls}-hidden" showProp="visible" visible="{{isOpen}}" animation="{{openAnimation}}">
+                <s-animate
+                    hiddenClassName="${prefixCls}-hidden"
+                    showProp="visible"
+                    visible="{{isOpen}}"
+                    animation="{{openAnimation}}">
                     <ul class="${prefixCls} {{rootPrefixCls}}-sub ${prefixCls}-{{mode}}"><slot /></ul>
                 </s-animate>
             </template>
@@ -240,7 +244,7 @@ export default san.defineComponent({
                 stretch="{{mode === 'horizontal' ? 'minWidth' : ''}}"
                 on-visibleChange="handleVisibleChange"
             >
-                <ul class="${prefixCls} {{rootPrefixCls}}-sub ${prefixCls}-{{mode}}" slot="popup"><slot /></ul>
+                <ul class="${prefixCls} {{rootPrefixCls}}-sub ${prefixCls}-vertical" slot="popup"><slot /></ul>
                 <div
                     class="{{menuPrefixCls}}-title"
                     aria-expanded="{{isOpen}}"

--- a/src/menu/subMenu.js
+++ b/src/menu/subMenu.js
@@ -72,7 +72,6 @@ export default san.defineComponent({
             openKeys: [],
             activeKey: [],
             openAnimation,
-            isSubMenu: true,
             inlineIndent: 16,
             builtinPlacements,
             trigger: 'hover',
@@ -157,12 +156,6 @@ export default san.defineComponent({
         santd_menu_addItem(payload) {
             this.items.push(payload.value);
         },
-        santd_menu_addSubMenu(payload) {
-            this.subMenus.push(payload.value);
-        },
-        santd_menu_isSelected(payload) {
-            this.data.set('isChildrenSelected', true);
-        },
         santd_menu_itemClick(payload) {
             if (this.data.get('mode') !== 'inline') {
                 this.data.set('noSubClick', false);
@@ -241,14 +234,7 @@ export default san.defineComponent({
                 style="display: block;"
                 popupPlacement="{{inFoldedItem ? 'leftTop' : (mode === 'horizontal' ? 'bottomCenter' : 'rightTop')}}"
                 builtinPlacements="{{builtinPlacements}}"
-                popupAlign="{{popupAlign}}"
-                popupTransitionName="{{transitionName}}"
-                defaultPopupVisible="{{defaultVisible}}"
                 getPopupContainer="{{getPopupContainer()}}"
-                mouseEnterDelay="{{mouseEnterDelay}}"
-                mouseLeaveDelay="{{mouseLeaveDelay}}"
-                popupClassName="{{overlayClassName}}"
-                popupStyle="{{overlayStyle}}"
                 action="hover"
                 visible="{{isOpen}}"
                 stretch="{{mode === 'horizontal' ? 'minWidth' : ''}}"


### PR DESCRIPTION
建议一个一个commit来review，会比较清晰，因为每个commit都是相对独立的。

说明：
1. 之所以要升级san，是因为为了能用s-show。
2. antd的Menu组件的子菜单都是垂直菜单，如下图所示，所以santd也和它对齐。

![image](https://user-images.githubusercontent.com/28821810/109828387-8d639c00-7c77-11eb-9ca6-4f87b9e19885.png)
