### PR TITLE
docs: 修复官网没有 favicon 的问题

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -40,7 +40,7 @@ async function deploy() {
 
         spinner = ora('git clone santd');
         spinner.start();
-        await execa('cp', ['../site/theme/static/img/logo.svg', './site/favicon.png'], {cwd: `${output}`});
+        await execa('cp', ['../site/theme/static/img/logo.svg', './site/favicon.svg'], {cwd: `${output}`});
 
         // 3. 拷贝分支gh-pages代码到本地
         // await execa('git', ['clone', '-b', 'gh-pages', 'git@github.com:ecomfe/santd.git'], {cwd: `${output}`});

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <link rel="icon" href="/santd/favicon.png">
+    <link rel="icon" href="/santd/favicon.svg">
     <title>Santd - San Toolkit for Ant Design</title>
 </head>
 


### PR DESCRIPTION
问题原因应该是 svg 图片不能通过直接改后缀名变成 png 图片，直接改后缀名的话，图片就挂了。
应该是这么修的，线下不好验证。
我觉得可以不用特地为这个改动更新一次官网，而是等下次需要更新官网时一起看看这个改动生效了没。