### PR TITLE
fix: 修复远程搜索重置data不显示title

### DIFF
--- a/src/select/MultipleSelector.js
+++ b/src/select/MultipleSelector.js
@@ -6,10 +6,13 @@
 import san, {DataTypes} from 'san';
 import {
     getMapKey,
+    memoize,
     prefixCls,
     preventDefaultEvent,
     toTitle
 } from './util';
+
+const getOptionsInfoWithMemory = memoize();
 
 export default san.defineComponent({
     template: `
@@ -75,7 +78,7 @@ export default san.defineComponent({
             }
 
             let selectedItems = selectedValues.map(val => {
-                let info = optionsInfo[getMapKey(val)] || {label: val};
+                let info = getOptionsInfoWithMemory(optionsInfo)[getMapKey(val)] || {label: val};
                 let content = info.label;
                 const title = toTitle(info.title || content);
 

--- a/src/select/util.js
+++ b/src/select/util.js
@@ -38,6 +38,14 @@ export function getMapKey(value) {
     return `${typeof value}-${value}`;
 }
 
+export function memoize() {
+    let cache = {};
+    return function (obj) {
+        cache = {...cache, ...obj};
+        return cache;
+    };
+}
+
 export function preventDefaultEvent(e) {
     e.preventDefault();
 }


### PR DESCRIPTION
问题原因：组件传入的optionsInfo对象每次都是最新的，远程搜索后 data 如果重置，之前的 optionsInfo 就会清空，导致无法显示 optionsInfo 中的 title。

解决办法：把 optionsInfo 对象缓存起来