### PR TITLE
fix: Upload.Dragger missing accept option.

### DIFF
--- a/src/upload/Upload.js
+++ b/src/upload/Upload.js
@@ -292,6 +292,7 @@ export default san.defineComponent({
             on-dragLeave="handleFileDrop"
         >
             <s-upload
+                accept="{{accept}}"
                 prefixCls="${prefixCls}"
                 listType="{{listType}}"
                 action="{{action}}"


### PR DESCRIPTION
Upload.Dragger 组件会错误的丢失 accept 属性
这会导致用户设置的 accept 属性无效，无法限制上传的文件类型。
这与 antd 中的相同组件行为不一致，从逻辑上看，可能是一个简单的模版属性丢失。